### PR TITLE
fix: Skip secret version creation when secret_string and secret_binary are null [INFRA-12625]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.2] - 2025-12-01
+
+### Fixed
+
+- Skip creating `aws_secretsmanager_secret_version` when both `secret_string` and `secret_binary` are null. This allows creating a "secret shell" for manually-managed secrets where the actual secret value is populated externally (e.g., via AWS Console or CLI). Previously, passing null would cause AWS API error: `InvalidRequestException: You must provide either SecretString or SecretBinary`.
+
 ## [2.0.1](https://github.com/terraform-aws-modules/terraform-aws-secrets-manager/compare/v2.0.0...v2.0.1) (2025-10-21)
 
 ### Bug Fixes

--- a/main.tf
+++ b/main.tf
@@ -93,8 +93,15 @@ resource "aws_secretsmanager_secret_policy" "this" {
 # Version
 ################################################################################
 
+# Local to determine if we have a secret value to store
+# When both secret_string and secret_binary are null, skip creating the version
+# This allows creating a "secret shell" for manually-managed secrets
+locals {
+  has_secret_value = var.secret_string != null || var.secret_binary != null
+}
+
 resource "aws_secretsmanager_secret_version" "this" {
-  count = var.create && !(var.enable_rotation || var.ignore_secret_changes) ? 1 : 0
+  count = var.create && !(var.enable_rotation || var.ignore_secret_changes) && local.has_secret_value ? 1 : 0
 
   region = var.region
 
@@ -107,7 +114,7 @@ resource "aws_secretsmanager_secret_version" "this" {
 }
 
 resource "aws_secretsmanager_secret_version" "ignore_changes" {
-  count = var.create && (var.enable_rotation || var.ignore_secret_changes) ? 1 : 0
+  count = var.create && (var.enable_rotation || var.ignore_secret_changes) && local.has_secret_value ? 1 : 0
 
   region = var.region
 

--- a/wrappers/README.md
+++ b/wrappers/README.md
@@ -12,9 +12,9 @@ This wrapper does not implement any extra functionality.
 
 ```hcl
 terraform {
-  source = "tfr:///terraform-aws-modules/secrets-manager/aws//wrappers"
+  source = "tfr:///terraform-aws-modules/fork-terraform-aws-secrets-manager/aws//wrappers"
   # Alternative source:
-  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-secrets-manager.git//wrappers?ref=master"
+  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-fork-terraform-aws-secrets-manager.git//wrappers?ref=master"
 }
 
 inputs = {
@@ -42,7 +42,7 @@ inputs = {
 
 ```hcl
 module "wrapper" {
-  source = "terraform-aws-modules/secrets-manager/aws//wrappers"
+  source = "terraform-aws-modules/fork-terraform-aws-secrets-manager/aws//wrappers"
 
   defaults = { # Default values
     create = true


### PR DESCRIPTION
## Summary

- Skip creating `aws_secretsmanager_secret_version` when both `secret_string` and `secret_binary` are null
- This allows creating a "secret shell" for manually-managed secrets where the actual value is populated externally

## Problem

When `terraform-aws-secrets-manager` module passes `null` for manually-managed secrets (to avoid overwriting existing values with a placeholder), the AWS API rejects with:

```
InvalidRequestException: You must provide either SecretString or SecretBinary
```

This broke the fix in [terraform-aws-secrets-manager PR #16](https://github.com/verygood-ops/terraform-aws-secrets-manager/pull/16) which was intended to prevent placeholder values from overwriting manually-set secrets.

Failing CI: https://github.com/verygood-ops/terraform-aws-vgs-preferences-service/actions/runs/19778400441/job/56674956624?pr=26

## Solution

Added a `has_secret_value` local that checks if either `secret_string` or `secret_binary` is non-null. Both `aws_secretsmanager_secret_version` resources now include this condition in their count expression, skipping version creation entirely when no secret value is provided.

## Workflow for Manual Secrets

After this fix, the workflow for `input_method="manual"` secrets is:

1. Terraform creates the secret resource (`aws_secretsmanager_secret`)
2. Terraform skips creating the initial version (no placeholder written)
3. Users manually add the first secret version via AWS Console/CLI
4. Subsequent Terraform runs don't overwrite the manual value (due to `ignore_secret_changes = true`)

## Test Plan

- [ ] Verify existing automated secrets (with `secret_value` set) continue to work
- [ ] Verify manual secrets can be created without initial version
- [ ] Verify terraform-aws-vgs-preferences-service CI passes after version bump